### PR TITLE
add article container relations / add bullet-list-item to regular article

### DIFF
--- a/design/source/components/Containers/article-container.html
+++ b/design/source/components/Containers/article-container.html
@@ -73,7 +73,8 @@
       },
       "footer": {
         "allowedChildren": [
-          "halves"
+          "halves",
+          "halves-article-footer"
         ],
         "defaultComponents": {
           "paragraph": "paragraph",

--- a/design/source/components/Lists/bullet-list-item.html
+++ b/design/source/components/Lists/bullet-list-item.html
@@ -2,7 +2,9 @@
 {
   "name": "bullet-list-item",
   "label": "Bullet List Item",
-  "allowedParents": ["bullet-list"]
+  "description": "A bullet list item",
+  "allowedParents": ["bullet-list"],
+  "iconUrl": "https://livingdocs-assets.s3.amazonaws.com/magazine-design/assets/images/icons-components/icon_unordered_list.svg"
 }
 </script>
 

--- a/design/source/components/Lists/bullet-list.html
+++ b/design/source/components/Lists/bullet-list.html
@@ -2,7 +2,7 @@
 {
   "label": "Bullet List",
   "name": "bullet-list",
-  "description": "A bullet point",
+  "description": "A bullet list",
   "allowedParents": ["article-container"],
   "iconUrl": "https://livingdocs-assets.s3.amazonaws.com/magazine-design/assets/images/icons-components/icon_unordered_list.svg",
   "properties": ["list-type"],

--- a/design/source/config.json
+++ b/design/source/config.json
@@ -1,11 +1,11 @@
 {
   "name": "living-times",
   "label": "Living Times",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "license": "Copyright (c) 2018 Livingdocs AG, all rights reserved",
 
   "assets": {
-    "basePath": "https://cdn.livingdocs.io/designs/living-times/0.0.13",
+    "basePath": "https://cdn.livingdocs.io/designs/living-times/0.0.14",
     "css": ["./styles.css"],
     "js": ["./scripts.js"]
   },

--- a/design/source/config.json
+++ b/design/source/config.json
@@ -183,7 +183,7 @@
             ],
             "footer": [
               {
-                "identifier": "living-times.halves",
+                "identifier": "living-times.halves-article-footer",
                 "content": {
                   "title": "Recommended Stories"
                 },
@@ -209,7 +209,7 @@
         },
         {
           "label": "Text",
-          "components": ["paragraph", "quote", "separator", "bullet-list"]
+          "components": ["paragraph", "quote", "separator", "bullet-list", "bullet-list-item"]
         },
         {
           "label": "Images",
@@ -264,7 +264,7 @@
         },
         {
           "label": "Text",
-          "components": ["paragraph", "quote", "separator", "bullet-list"]
+          "components": ["paragraph", "quote", "separator", "bullet-list", "bullet-list-item"]
         },
         {
           "label": "Images",

--- a/mocks/publications/articles/11.json
+++ b/mocks/publications/articles/11.json
@@ -9,7 +9,7 @@
         "layout": "regular",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/articles/13.json
+++ b/mocks/publications/articles/13.json
@@ -9,7 +9,7 @@
         "layout": "regular",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/articles/15.json
+++ b/mocks/publications/articles/15.json
@@ -9,7 +9,7 @@
         "layout": "regular",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/articles/17.json
+++ b/mocks/publications/articles/17.json
@@ -9,7 +9,7 @@
         "layout": "regular",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/articles/20.json
+++ b/mocks/publications/articles/20.json
@@ -9,7 +9,7 @@
         "layout": "regular",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/articles/22.json
+++ b/mocks/publications/articles/22.json
@@ -9,7 +9,7 @@
         "layout": "regular",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/articles/24.json
+++ b/mocks/publications/articles/24.json
@@ -9,7 +9,7 @@
         "layout": "regular",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/articles/27.json
+++ b/mocks/publications/articles/27.json
@@ -9,7 +9,7 @@
         "layout": "regular",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/articles/29.json
+++ b/mocks/publications/articles/29.json
@@ -9,7 +9,7 @@
         "layout": "regular",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/articles/31.json
+++ b/mocks/publications/articles/31.json
@@ -9,7 +9,7 @@
         "layout": "regular",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/articles/33.json
+++ b/mocks/publications/articles/33.json
@@ -9,7 +9,7 @@
         "layout": "regular",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/articles/39.json
+++ b/mocks/publications/articles/39.json
@@ -9,7 +9,7 @@
         "layout": "regular",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/articles/42.json
+++ b/mocks/publications/articles/42.json
@@ -9,7 +9,7 @@
         "layout": "regular",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/articles/44.json
+++ b/mocks/publications/articles/44.json
@@ -9,7 +9,7 @@
         "layout": "regular",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/articles/46.json
+++ b/mocks/publications/articles/46.json
@@ -9,7 +9,7 @@
         "layout": "regular",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/articles/48.json
+++ b/mocks/publications/articles/48.json
@@ -9,7 +9,7 @@
         "layout": "regular",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/authors/12.json
+++ b/mocks/publications/authors/12.json
@@ -9,7 +9,7 @@
         "layout": "author",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/authors/14.json
+++ b/mocks/publications/authors/14.json
@@ -9,7 +9,7 @@
         "layout": "author",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/authors/16.json
+++ b/mocks/publications/authors/16.json
@@ -9,7 +9,7 @@
         "layout": "author",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/authors/18.json
+++ b/mocks/publications/authors/18.json
@@ -9,7 +9,7 @@
         "layout": "author",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/authors/21.json
+++ b/mocks/publications/authors/21.json
@@ -9,7 +9,7 @@
         "layout": "author",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/authors/23.json
+++ b/mocks/publications/authors/23.json
@@ -9,7 +9,7 @@
         "layout": "author",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/authors/25.json
+++ b/mocks/publications/authors/25.json
@@ -9,7 +9,7 @@
         "layout": "author",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/authors/26.json
+++ b/mocks/publications/authors/26.json
@@ -9,7 +9,7 @@
         "layout": "author",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/authors/28.json
+++ b/mocks/publications/authors/28.json
@@ -9,7 +9,7 @@
         "layout": "author",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/authors/30.json
+++ b/mocks/publications/authors/30.json
@@ -9,7 +9,7 @@
         "layout": "author",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/authors/32.json
+++ b/mocks/publications/authors/32.json
@@ -9,7 +9,7 @@
         "layout": "author",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/authors/34.json
+++ b/mocks/publications/authors/34.json
@@ -9,7 +9,7 @@
         "layout": "author",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/authors/43.json
+++ b/mocks/publications/authors/43.json
@@ -9,7 +9,7 @@
         "layout": "author",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/authors/45.json
+++ b/mocks/publications/authors/45.json
@@ -9,7 +9,7 @@
         "layout": "author",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/authors/47.json
+++ b/mocks/publications/authors/47.json
@@ -9,7 +9,7 @@
         "layout": "author",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/galleries/38.json
+++ b/mocks/publications/galleries/38.json
@@ -9,7 +9,7 @@
         "layout": "gallery",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/galleries/40.json
+++ b/mocks/publications/galleries/40.json
@@ -9,7 +9,7 @@
         "layout": "gallery",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/galleries/41.json
+++ b/mocks/publications/galleries/41.json
@@ -9,7 +9,7 @@
         "layout": "gallery",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/pages/10.json
+++ b/mocks/publications/pages/10.json
@@ -9,7 +9,7 @@
         "layout": "page",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/pages/3.json
+++ b/mocks/publications/pages/3.json
@@ -9,7 +9,7 @@
         "layout": "page",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/pages/4.json
+++ b/mocks/publications/pages/4.json
@@ -9,7 +9,7 @@
         "layout": "page",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/pages/5.json
+++ b/mocks/publications/pages/5.json
@@ -9,7 +9,7 @@
         "layout": "page",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/pages/6.json
+++ b/mocks/publications/pages/6.json
@@ -9,7 +9,7 @@
         "layout": "page",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/pages/7.json
+++ b/mocks/publications/pages/7.json
@@ -9,7 +9,7 @@
         "layout": "page",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/pages/8.json
+++ b/mocks/publications/pages/8.json
@@ -9,7 +9,7 @@
         "layout": "page",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/pages/9.json
+++ b/mocks/publications/pages/9.json
@@ -9,7 +9,7 @@
         "layout": "page",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/pages/home.json
+++ b/mocks/publications/pages/home.json
@@ -9,7 +9,7 @@
         "layout": "page",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/videos/35.json
+++ b/mocks/publications/videos/35.json
@@ -9,7 +9,7 @@
         "layout": "video",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/videos/36.json
+++ b/mocks/publications/videos/36.json
@@ -9,7 +9,7 @@
         "layout": "video",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {

--- a/mocks/publications/videos/37.json
+++ b/mocks/publications/videos/37.json
@@ -9,7 +9,7 @@
         "layout": "video",
         "design": {
             "name": "living-times",
-            "version": "0.0.13"
+            "version": "0.0.14"
         }
     },
     "metadata": {


### PR DESCRIPTION
# Description

For the copy-component case, the version 0.0.13 was a little bit inconsistent. 
- I was able to copy a halves-footer, but was not able to paste it
- I was able to copy a bullet-list-item, but was not able to paste it

This change fixes this behaviour.