### PR TITLE
Update Livingdocs SDK to ^0.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 node_modules
+package-lock.json
 design/dist
 npm-debug.log
 conf/secrets/*

--- a/package.json
+++ b/package.json
@@ -17,6 +17,15 @@
     "start:magazine:watch": "nodemon --watch conf --watch lib --watch app app/index.js",
     "start": "npm-run-all design:build design:dev:mocked"
   },
+  "dependencies": {
+    "@livingdocs/conf": "^1.0.1",
+    "@livingdocs/node-sdk": "^0.1.0",
+    "combined-slugify": "^2.1.0",
+    "compression": "^1.7.2",
+    "express": "^4.16.3",
+    "moment": "^2.11.0",
+    "photoswipe": "^4.1.2"
+  },
   "devDependencies": {
     "autoprefixer": "^8.0.0",
     "babel-core": "^6.25.0",
@@ -48,14 +57,5 @@
     "webpack-cli": "^3.0.3",
     "webpack-dev-middleware": "^3.1.0",
     "webpack-hot-middleware": "^2.21.2"
-  },
-  "dependencies": {
-    "@livingdocs/conf": "^1.0.1",
-    "@livingdocs/node-sdk": "^0.1.0",
-    "combined-slugify": "^2.1.0",
-    "compression": "^1.7.2",
-    "express": "^4.16.3",
-    "moment": "^2.11.0",
-    "photoswipe": "^4.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@livingdocs/conf": "^1.0.1",
-    "@livingdocs/node-sdk": "^0.1.0",
+    "@livingdocs/node-sdk": "^0.2.1",
     "combined-slugify": "^2.1.0",
     "compression": "^1.7.2",
     "express": "^4.16.3",


### PR DESCRIPTION
This update brings proxy support to the magazine and also introduces some more methods that could be of use.