### PR TITLE
use fallback date from last_publication

### DIFF
--- a/conf/includes/content_extractor.js
+++ b/conf/includes/content_extractor.js
@@ -68,11 +68,11 @@ function flag ({metadata = {}} = {}) {
   return metadata.flag
 }
 
-function publishDate ({metadata = {}, first_publication: firstPublication = {}} = {}) {
+function publishDate ({metadata = {}, last_publication: lastPublication = {}} = {}) {
   try {
     const metadataDate = moment(metadata.publishDate)
     if (metadataDate.isValid()) return metadataDate.calendar()
-    const recordDate = moment(firstPublication.created_at)
+    const recordDate = moment(lastPublication.created_at)
     if (recordDate.isValid()) return recordDate.calendar()
     return ''
   } catch (e) {


### PR DESCRIPTION
The member `first_publication` is removed in the new document API. We use `last_publication` as a fallback. The primary date provider is the metadata plugin anyway.