### PR TITLE
fix(living-times): add gallery-teasers to articles

### DIFF
--- a/design/source/components/Containers/article-container.html
+++ b/design/source/components/Containers/article-container.html
@@ -28,7 +28,11 @@
           "quote",
           "teaser-author",
           "video-container",
-          "gallery-container"
+          "gallery-container",
+          "teaser-gallery-hero",
+          "teaser-gallery",
+          "teaser-video-hero",
+          "teaser-video"
         ],
         "defaultComponents": {
           "paragraph": "paragraph",

--- a/design/source/config.json
+++ b/design/source/config.json
@@ -1,11 +1,11 @@
 {
   "name": "living-times",
   "label": "Living Times",
-  "version": "0.0.19",
+  "version": "0.0.21",
   "license": "Copyright (c) 2018 Livingdocs AG, all rights reserved",
 
   "assets": {
-    "basePath": "https://cdn.livingdocs.io/designs/living-times/0.0.14",
+    "basePath": "https://cdn.livingdocs.io/designs/living-times/0.0.21",
     "css": ["./styles.css"],
     "js": ["./scripts.js"]
   },
@@ -222,6 +222,14 @@
         {
           "label": "Footer",
           "components": ["halves-article-footer", "teaser-card"]
+        },
+        {
+          "label": "Gallery Teasers",
+          "components": ["teaser-gallery-hero", "teaser-gallery"]
+        },
+        {
+          "label": "Video Teasers",
+          "components": ["teaser-video-hero", "teaser-video"]
         },
         {
           "label": "Embeds",


### PR DESCRIPTION
## Changelog

- adds `teaser-gallery-hero`, `teaser-gallery`, `teaser-video-hero`, `teaser-video` to the **articles** for the living times design & magazine-example in the service

_Previously they were just components used in pages. Now in articles as well_